### PR TITLE
Change version in composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,6 +18,6 @@
         "phpunit/phpunit": "^10.3"
     },
     "require": {
-        "php": ">=7.4"
+        "php": "^7.4"
     }
 }


### PR DESCRIPTION
Isn't it better to use `^7.4` over `>=7.4`